### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci-pipeline-workflow.yml
+++ b/.github/workflows/ci-pipeline-workflow.yml
@@ -59,7 +59,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build & push Docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kakuzei/ui.kakuzei.com
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore